### PR TITLE
Fix: 500 Unknown column 'a.name' in 'where clause' Unknown column 'a.name' in 'where clause'

### DIFF
--- a/src/Assets/component/administrator/src/Model/NotesModel.jext
+++ b/src/Assets/component/administrator/src/Model/NotesModel.jext
@@ -217,9 +217,9 @@ class NotesModel extends ListModel
 			{
 				$search = '%' . trim($search) . '%';
 				$query->where(
-					'(' . $db->quoteName('a.name') . ' LIKE :name OR ' . $db->quoteName('a.alias') . ' LIKE :alias)'
+					'(' . $db->quoteName('a.title') . ' LIKE :title OR ' . $db->quoteName('a.alias') . ' LIKE :alias)'
 				);
-				$query->bind(':name', $search);
+				$query->bind(':title', $search);
 				$query->bind(':alias', $search);
 			}
 		}


### PR DESCRIPTION
500 Unknown column 'a.name' in 'where clause' Unknown column 'a.name' in 'where clause'